### PR TITLE
Disable Google icon URLs

### DIFF
--- a/cs-nearby-map.php
+++ b/cs-nearby-map.php
@@ -363,8 +363,8 @@ if(!class_exists('CspmNearbyMap')){
 		 */		 
 		function cspm_register_scripts(){
 								
-			$min_path = $this->plugin_settings['combine_files'] == 'seperate' ? '' : 'min/';
-			$min_prefix = $this->plugin_settings['combine_files'] == 'seperate' ? '' : '.min' ;
+                        $min_path = '';
+                        $min_prefix = '';
 			
 			wp_register_script('cspm_simplelightbox_js', $this->plugin_url .'js/'.$min_path.'simple-lightbox.jquery'.$min_prefix.'.js', array( 'jquery' ), $this->plugin_version, true);
 			wp_register_script('jquery-readmore', $this->plugin_url .'js/'.$min_path.'readmore'.$min_prefix.'.js', array( 'jquery' ), $this->plugin_version, true);				

--- a/js/pm-nearby-map.js
+++ b/js/pm-nearby-map.js
@@ -38,12 +38,10 @@ function initCustomNearbyMap() {
 
 // Egyszerű példa ikon választásra type szerint
 function getIconByType(type) {
-    const icons = {
-        'bowling': 'https://maps.google.com/mapfiles/kml/shapes/sports.png',
-        'gym': 'https://maps.google.com/mapfiles/kml/shapes/library_maps.png',
-        'default': 'https://maps.google.com/mapfiles/kml/shapes/info-i_maps.png'
-    };
-    return icons[type] || icons['default'];
+    if (typeof cspm_nearby_map !== 'undefined' && cspm_nearby_map.place_markers_file_url) {
+        return cspm_nearby_map.place_markers_file_url + type + '.png';
+    }
+    return null;
 }
 
 


### PR DESCRIPTION
## Summary
- use local icon path when adding markers
- always load unminified JS to make local overrides take effect

## Testing
- `php -l` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68554f54ab548323b84b870d6a263cc2