### PR TITLE
Fix custom type loading from JSON

### DIFF
--- a/admin/options-page/settings.php
+++ b/admin/options-page/settings.php
@@ -651,10 +651,16 @@ add_action('admin_menu', function() {
 });
 
 function render_custom_nearby_locations_page() {
-    if (isset($_POST['save_custom_locations'])) {
-        $locations = sanitize_textarea_field($_POST['custom_locations_json']);
-        update_option('custom_nearby_locations', $locations);
-        echo '<div class="updated"><p>Helyek elmentve!</p></div>';
+    if ( isset( $_POST['save_custom_locations'] ) ) {
+        $raw_json = wp_unslash( $_POST['custom_locations_json'] );
+        $decoded  = json_decode( $raw_json, true );
+
+        if ( is_array( $decoded ) ) {
+            update_option( 'custom_nearby_locations', wp_json_encode( $decoded ) );
+            echo '<div class="updated"><p>Helyek elmentve!</p></div>';
+        } else {
+            echo '<div class="error"><p>Hibás JSON formátum!</p></div>';
+        }
     }
 
     $saved_locations = get_option('custom_nearby_locations', '[]');

--- a/functions.php
+++ b/functions.php
@@ -19,7 +19,7 @@ function return_custom_nearby_locations() {
  */
 function cspmnm_get_json_types() {
     $types = array();
-    $json  = get_option('custom_nearby_locations', '');
+    $json  = wp_unslash( get_option('custom_nearby_locations', '' ) );
 
     if ( ! empty( $json ) ) {
         $locations = json_decode( $json, true );

--- a/js/pm-nearby-map.js
+++ b/js/pm-nearby-map.js
@@ -17,7 +17,9 @@ function initCustomNearbyMap() {
     });
 
     // Lekérjük a WP adminban megadott helyeket
-    fetch('/wp-admin/admin-ajax.php?action=get_custom_nearby_locations')
+    const ajaxUrl = ( typeof cspm_nearby_map !== 'undefined' && cspm_nearby_map.ajax_url ) ? cspm_nearby_map.ajax_url : '/wp-admin/admin-ajax.php';
+
+    fetch(ajaxUrl + '?action=get_custom_nearby_locations')
         .then(response => response.json())
         .then(data => {
             customLocations = Array.isArray(data) ? data : [];


### PR DESCRIPTION
## Summary
- allow saving and validating custom JSON locations
- sanitize JSON option retrieval
- use localized `ajax_url` when requesting locations

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_b_685551d74b388323ba27e67e35f4b362