### PR TITLE
Fix slug generation to match JS

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -26,6 +26,12 @@ function return_custom_nearby_locations() {
  */
 function cspmnm_slugify_type( $type ) {
     $type = strtolower( $type );
+
+    // Remove accents to match the JavaScript slugify implementation
+    if ( function_exists( 'remove_accents' ) ) {
+        $type = remove_accents( $type );
+    }
+
     $type = preg_replace( '/[\s-]+/', '_', $type );
     $type = preg_replace( '/[^a-z0-9_]/', '', $type );
     return trim( $type, '_' );


### PR DESCRIPTION
## Summary
- remove accents in PHP slug generator to align with JS

## Testing
- `php -l functions.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_b_685565d06c9483239e24c1d1ec64515e