### PR TITLE
Fix custom type icons

### DIFF
--- a/js/pm-nearby-map.js
+++ b/js/pm-nearby-map.js
@@ -57,9 +57,14 @@ function initCustomNearbyMap() {
 }
 
 // Egyszerű példa ikon választásra a type slug alapján
+const typeAliases = {
+    bowling: 'bowling_alley'
+};
+
 function getIconByType(slug) {
     if (typeof cspm_nearby_map !== 'undefined' && cspm_nearby_map.place_markers_file_url) {
-        return cspm_nearby_map.place_markers_file_url + slug + '.png';
+        const mapped = typeAliases[slug] || slug;
+        return cspm_nearby_map.place_markers_file_url + mapped + '.png';
     }
     return null;
 }


### PR DESCRIPTION
## Summary
- connect custom types like `bowling` with existing markers

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68592b791450832393371e41638f5073