### PR TITLE
Fix undefined function call

### DIFF
--- a/cs-nearby-map.php
+++ b/cs-nearby-map.php
@@ -1279,7 +1279,9 @@ if(!class_exists('CspmNearbyMap')){
 				nearby_map_object[map_id] = plugin_map.gmap3("get");					
 				origin[map_id] = new google.maps.LatLng(<?php echo $centerLat; ?>, <?php echo $centerLng; ?>);											
 				
-				cspm_init_nearby_directions_display(map_id);											
+                                if (typeof cspm_init_nearby_directions_display === 'function') {
+                                    cspm_init_nearby_directions_display(map_id);
+                                }
 				
 				<?php 
 				


### PR DESCRIPTION
## Summary
- avoid calling missing `cspm_init_nearby_directions_display` if it doesn't exist

## Testing
- `php -l cs-nearby-map.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_b_68594a1a1b0c83238c10b877b1ae8f58