### PR TITLE
Fix Unicode escaping in custom location JSON

### DIFF
--- a/admin/options-page/settings.php
+++ b/admin/options-page/settings.php
@@ -656,7 +656,10 @@ function render_custom_nearby_locations_page() {
         $decoded  = json_decode( $raw_json, true );
 
         if ( is_array( $decoded ) ) {
-            update_option( 'custom_nearby_locations', wp_json_encode( $decoded ) );
+            // Preserve UTF-8 characters so accents don't get converted to
+            // \uXXXX sequences when saving the JSON string.
+            $encoded = wp_json_encode( $decoded, JSON_UNESCAPED_UNICODE );
+            update_option( 'custom_nearby_locations', $encoded );
             echo '<div class="updated"><p>Helyek elmentve!</p></div>';
         } else {
             echo '<div class="error"><p>Hibás JSON formátum!</p></div>';


### PR DESCRIPTION
## Summary
- preserve UTF-8 characters when saving custom locations

## Testing
- `php -l admin/options-page/settings.php`
- `php -l functions.php`


------
https://chatgpt.com/codex/tasks/task_b_68594ed938748323a0f998c43a6c9074