### PR TITLE
Allow editing custom locations JSON as raw input

### DIFF
--- a/admin/options-page/settings.php
+++ b/admin/options-page/settings.php
@@ -656,10 +656,9 @@ function render_custom_nearby_locations_page() {
         $decoded  = json_decode( $raw_json, true );
 
         if ( is_array( $decoded ) ) {
-            // Preserve UTF-8 characters so accents don't get converted to
-            // \uXXXX sequences when saving the JSON string.
-            $encoded = wp_json_encode( $decoded, JSON_UNESCAPED_UNICODE );
-            update_option( 'custom_nearby_locations', $encoded );
+            // Save the raw JSON exactly as provided so the admin can
+            // control formatting and ordering.
+            update_option( 'custom_nearby_locations', $raw_json );
             echo '<div class="updated"><p>Helyek elmentve!</p></div>';
         } else {
             echo '<div class="error"><p>Hibás JSON formátum!</p></div>';


### PR DESCRIPTION
## Summary
- preserve user-provided JSON when saving custom locations

## Testing
- `php -l admin/options-page/settings.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_685950f5d36083239f758effcde715e9