### PR TITLE
Enable click filtering and log loaded locations

### DIFF
--- a/js/pm-nearby-map.js
+++ b/js/pm-nearby-map.js
@@ -75,6 +75,7 @@ function initCustomNearbyMap() {
     fetch(ajaxUrl + '?action=get_custom_nearby_locations')
         .then(response => response.json())
         .then(data => {
+            console.log('Loaded locations from JSON:', data);
             customLocations = Array.isArray(data)
                 ? data.map(p => Object.assign({}, p, { slug: slugifyType(p.type || '') }))
                 : [];
@@ -167,6 +168,9 @@ function bindCategoryHover() {
         });
         cat.addEventListener('mouseleave', () => {
             showFilteredLocations('');
+        });
+        cat.addEventListener('click', () => {
+            showFilteredLocations(slug);
         });
     });
 }


### PR DESCRIPTION
## Summary
- log JSON data when custom locations load
- allow clicking category items to filter markers

## Testing
- `npm --version`
- `node --version`


------
https://chatgpt.com/codex/tasks/task_b_6859562734948323a7187147bec60395