### PR TITLE
Fix missing icons for Hungarian slugs

### DIFF
--- a/js/pm-nearby-map.js
+++ b/js/pm-nearby-map.js
@@ -156,8 +156,11 @@ const typeAliases = {
     egeszsegugyi_letesitmenyek: 'hospital',
     oktatasi_intezmenyek: 'school',
     jszakai_let__klub: 'night_club',
+    ejszakai_elet__klub: 'night_club',
     sport_es_rekreacio: 'stadium',
     ttermek: 'restaurant',
+    ettermek: 'restaurant',
+    mozi: 'movie_theater',
     kulturalis_helyszinek: 'museum',
     kavezok: 'cafe'
 };


### PR DESCRIPTION
## Summary
- map Hungarian place slugs like `mozi` and `ettermek` to default icons
- add alias for `ejszakai_elet__klub`

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_685a4d0f321c8323aff7927e446e6a70